### PR TITLE
[BUGFIX] Fix f:link.email ViewHelper by adding ContentObjectRenderer to RenderJobFactory

### DIFF
--- a/.github/workflows/tasks.yml
+++ b/.github/workflows/tasks.yml
@@ -2,7 +2,15 @@ name: Tasks
 
 on:
   push:
+    branches:
+      - "*"
+    tags:
+      - "*"
   pull_request:
+    branches:
+      - "*"
+  schedule:
+    - cron: "0 2 * * 1-5"
 
 jobs:
   lint-php:

--- a/Classes/Factory/RenderJobFactory.php
+++ b/Classes/Factory/RenderJobFactory.php
@@ -22,6 +22,7 @@ use TYPO3\CMS\Core\TypoScript\IncludeTree\SysTemplateRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\RootlineUtility;
 use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 use function json_decode;
@@ -114,6 +115,9 @@ final readonly class RenderJobFactory
 
         $renderRequest = $renderRequest->withAttribute('frontend.typoscript', $plainFrontendTypoScript);
 
+        $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $renderRequest = $renderRequest->withAttribute('currentContentObject', $contentObjectRenderer);
+
         // set the global, since some ViewHelper still fallback to $GLOBALS['TYPO3_REQUEST']
         $GLOBALS['TYPO3_REQUEST'] = $renderRequest;
 
@@ -126,6 +130,7 @@ final readonly class RenderJobFactory
                 new PageArguments(0, '0', []),
                 $this->frontendUserAuthentication
             );
+            $tsfe->cObj = $contentObjectRenderer;
             $GLOBALS['TSFE'] = $tsfe;
             $tsfe->initializePageRenderer($renderRequest);
             $this->preparePageContentGeneration($plainFrontendTypoScript, $tsfe, $normalizedParams);

--- a/Documentation/dummy-project/src/extensions/dummy_extension/Components/EmailLink/EmailLink.html
+++ b/Documentation/dummy-project/src/extensions/dummy_extension/Components/EmailLink/EmailLink.html
@@ -1,0 +1,5 @@
+<f:argument name="email" type="string" description="Email address to render as a mailto link" />
+
+<div class="email-link-example">
+  <f:link.email email="{email}">Write us</f:link.email>
+</div>

--- a/Documentation/dummy-project/src/extensions/dummy_extension/Components/EmailLink/EmailLink.stories.ts
+++ b/Documentation/dummy-project/src/extensions/dummy_extension/Components/EmailLink/EmailLink.stories.ts
@@ -1,0 +1,14 @@
+import { type Meta, type StoryObj, fetchComponent } from '@andersundsehr/storybook-typo3';
+
+/**
+ * Regression fixture for email link rendering in Storybook previews.
+ */
+export default {
+  component: await fetchComponent('de:emailLink'),
+} satisfies Meta;
+
+export const Default: StoryObj = {
+  args: {
+    email: 'test@example.com',
+  },
+};

--- a/Documentation/dummy-project/tests/email-link.spec.ts
+++ b/Documentation/dummy-project/tests/email-link.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test';
+
+test('renders f:link.email without TYPO3 request errors', async ({ page }) => {
+  await page.goto('/?path=/story/extensions-dummy-extension-components-emaillink--default');
+
+  const frame = page.locator('iframe[title="storybook-preview-iframe"]').contentFrame();
+  const story = frame.locator('#storybook-root');
+
+  await expect(
+    story.getByRole('link', { name: 'Write us' }),
+    'email link should render in the preview iframe'
+  ).toHaveAttribute('href', 'mailto:test@example.com', { timeout: 10_000 });
+});

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "require-dev": {
     "pluswerk/grumphp-config": "^10.1.3",
-    "saschaegerer/phpstan-typo3": "^2.0.0 || ^3.0.0",
+    "saschaegerer/phpstan-typo3": "^2.0.0 || ^3.0.1",
     "ssch/typo3-rector": "^3.1.0",
     "typo3/cms-extbase": "^13.4.15 || ^14.0.0"
   },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -15,7 +15,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => InstalledVersions::getPrettyVersion('andersundsehr/storybook'),
     'constraints' => [
         'depends' => [
-            'typo3' => '13.4.15-14.0.999',
+            'typo3' => '13.4.15-14.3.999',
         ],
         'conflicts' => [],
         'suggests' => [],

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,6 +7,12 @@ parameters:
 			path: Classes/Factory/RenderJobFactory.php
 
 		-
+			message: '#^Access to property \$cObj on an unknown class TYPO3\\CMS\\Frontend\\Controller\\TypoScriptFrontendController\.$#'
+			identifier: class.notFound
+			count: 2
+			path: Classes/Factory/RenderJobFactory.php
+
+		-
 			message: '#^Call to method initializePageRenderer\(\) on an unknown class TYPO3\\CMS\\Frontend\\Controller\\TypoScriptFrontendController\.$#'
 			identifier: class.notFound
 			count: 1


### PR DESCRIPTION
Added ContentObjectRenderer instance to render request attributes. Or for TYPO3 13 in the TSFE.

closes #100 
fixes #98 