### PR TITLE
[BUGFIX] validate transformer return types by assignability

### DIFF
--- a/.github/workflows/tasks.yml
+++ b/.github/workflows/tasks.yml
@@ -39,6 +39,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.php }}-composer-
       - run: composer require typo3/minimal="^${{ matrix.typo3 }}" --dev --ignore-platform-req=php+
       - run: ./vendor/bin/grumphp run --ansi
+      - run: composer test:unit
 
   playwright:
     name: "playwright: php: ${{ matrix.php }} TYPO3: ${{ matrix.typo3 }} Storybook: ${{ matrix.storybook }}"

--- a/Classes/Transformer/TransformersFactory.php
+++ b/Classes/Transformer/TransformersFactory.php
@@ -17,8 +17,10 @@ use TYPO3Fluid\Fluid\Core\Component\ComponentTemplateResolverInterface;
 use function array_keys;
 use function class_exists;
 use function enum_exists;
+use function explode;
 use function file_exists;
 use function in_array;
+use function interface_exists;
 use function preg_replace;
 use function str_ends_with;
 
@@ -113,7 +115,7 @@ final readonly class TransformersFactory
         return $result;
     }
 
-    private function validateReturnType(ComponentDefinition $componentDefinition, Transformers $transformers): void
+    public function validateReturnType(ComponentDefinition $componentDefinition, Transformers $transformers): void
     {
         $argumentDefinitions = $componentDefinition->getArgumentDefinitions();
         foreach (array_keys($transformers->arguments) as $argumentName) {
@@ -124,19 +126,7 @@ final readonly class TransformersFactory
                 continue;
             }
 
-            if ($resultType !== $targetType) {
-                if (str_ends_with($targetType, '[]') && $resultType === 'array') {
-                    continue;
-                }
-
-                $targetIsClass = class_exists($targetType) || interface_exists($targetType);
-                $resultIsClass = class_exists($resultType) || interface_exists($resultType);
-                // If the target type is a class, interface or enum, we can check if the result type is a subclass or implementation
-                if ($targetIsClass && $resultIsClass && is_a($resultType, $targetType, true)) {
-                    continue;
-                }
-
-                // TODO use better type comparison
+            if (!$this->isTypeAssignable($resultType, $targetType)) {
                 throw new RuntimeException(
                     '🥺🙏 please report this!!! https://github.com/andersundsehr/storybook/issues The transformer for argument "' . $argumentName . '" returns a value of type "' . $resultType . '" but the component expects a value of type "' . $targetType . '". ' .
                         'Please adjust the transformer or the component definition.',
@@ -144,6 +134,49 @@ final readonly class TransformersFactory
                 );
             }
         }
+    }
+
+    private function isTypeAssignable(string $resultType, string $targetType): bool
+    {
+        foreach ($this->splitUnionType($resultType) as $resultTypePart) {
+            $isCompatible = false;
+            foreach ($this->splitUnionType($targetType) as $targetTypePart) {
+                if ($this->isSingleTypeAssignable($resultTypePart, $targetTypePart)) {
+                    $isCompatible = true;
+                    break;
+                }
+            }
+
+            if (!$isCompatible) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function splitUnionType(string $type): array
+    {
+        return explode('|', $type);
+    }
+
+    private function isSingleTypeAssignable(string $resultType, string $targetType): bool
+    {
+        if ($resultType === $targetType) {
+            return true;
+        }
+
+        if (str_ends_with($targetType, '[]') && $resultType === 'array') {
+            return true;
+        }
+
+        $targetIsClass = class_exists($targetType) || interface_exists($targetType);
+        $resultIsClass = class_exists($resultType) || interface_exists($resultType);
+
+        return $targetIsClass && $resultIsClass && is_a($resultType, $targetType, true);
     }
 
     private function loadArgumentTransformer(mixed $pdaFileName, ViewHelperName $viewHelperName): mixed

--- a/Tests/Unit/Transformer/TransformersFactoryTest.php
+++ b/Tests/Unit/Transformer/TransformersFactoryTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Andersundsehr\Storybook\Tests\Unit\Transformer;
+
+use Throwable;
+use Stringable;
+use Andersundsehr\Storybook\Service\ConfigService;
+use Andersundsehr\Storybook\Transformer\Transformer;
+use Andersundsehr\Storybook\Transformer\TransformerFactory;
+use Andersundsehr\Storybook\Transformer\Transformers;
+use Andersundsehr\Storybook\Transformer\TransformersFactory;
+use Andersundsehr\Storybook\Transformer\TypeTransformers;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+use TYPO3Fluid\Fluid\Core\Component\ComponentDefinition;
+use TYPO3Fluid\Fluid\Core\ViewHelper\ArgumentDefinition;
+
+final class TransformersFactoryTest extends UnitTestCase
+{
+    #[DataProvider('validReturnTypesDataProvider')]
+    public function testValidateReturnTypeAcceptsCompatibleTypes(string $targetType, string $returnType): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->createSubject()->validateReturnType(
+            $this->createComponentDefinition($targetType),
+            $this->createTransformers($returnType),
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function validReturnTypesDataProvider(): array
+    {
+        return [
+            'exact scalar match' => ['string', 'string'],
+            'mixed accepts any return type' => ['mixed', 'string'],
+            'array satisfies array-shape-like target' => ['string[]', 'array'],
+            'subclass satisfies parent/interface target' => [Throwable::class, RuntimeException::class],
+            'exact union type match' => ['string|int', 'string|int'],
+            'order different union type match' => ['string|int', 'int|string'],
+            'narrower scalar satisfies union target' => ['string|int', 'string'],
+            'class satisfies union target' => [Throwable::class . '|' . Stringable::class, RuntimeException::class],
+        ];
+    }
+
+    #[DataProvider('invalidReturnTypesDataProvider')]
+    public function testValidateReturnTypeThrowsForIncompatibleTypes(string $targetType, string $returnType): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionCode(4128088840);
+
+        $this->createSubject()->validateReturnType(
+            $this->createComponentDefinition($targetType),
+            $this->createTransformers($returnType),
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function invalidReturnTypesDataProvider(): array
+    {
+        return [
+            'different scalar type' => ['string', 'int'],
+            'broader union does not satisfy narrower target' => ['string', 'string|int'],
+        ];
+    }
+
+    private function createSubject(): TransformersFactory
+    {
+        $transformerFactory = new TransformerFactory(new class implements ContainerInterface {
+            public function get(string $id): mixed
+            {
+                throw new RuntimeException('No services available in unit test container.', 1589909511);
+            }
+
+            public function has(string $id): bool
+            {
+                return false;
+            }
+        });
+
+        return new TransformersFactory(
+            new TypeTransformers($transformerFactory),
+            $transformerFactory,
+            $this->createStub(ConfigService::class),
+        );
+    }
+
+    private function createComponentDefinition(string $targetType): ComponentDefinition
+    {
+        return new ComponentDefinition(
+            'storybook:test',
+            [
+                'title' => new ArgumentDefinition(
+                    'title',
+                    $targetType,
+                    'Test argument',
+                    false,
+                    null,
+                    false,
+                ),
+            ],
+            false,
+            [],
+        );
+    }
+
+    private function createTransformers(string $returnType): Transformers
+    {
+        return new Transformers(
+            [
+                'title' => new Transformer(
+                    static fn(): mixed => null,
+                    'test',
+                    $returnType,
+                    [],
+                    [],
+                ),
+            ],
+            'test.transformer.php',
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,21 @@
     "typo3fluid/fluid": "^4.3.0 || ^5.0.0"
   },
   "require-dev": {
+    "phpunit/phpunit": "^11.5",
     "pluswerk/grumphp-config": "^10.1.3",
     "saschaegerer/phpstan-typo3": "^2.0.0 || ^3.0.1",
     "ssch/typo3-rector": "^3.1.0",
-    "typo3/cms-extbase": "^13.4.15 || ^14.0.0"
+    "typo3/cms-extbase": "^13.4.15 || ^14.0.0",
+    "typo3/testing-framework": "^9.0"
   },
   "autoload": {
     "psr-4": {
       "Andersundsehr\\Storybook\\": "Classes/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Andersundsehr\\Storybook\\Tests\\": "Tests/"
     }
   },
   "config": {
@@ -43,5 +50,11 @@
     "typo3/cms": {
       "extension-key": "storybook"
     }
+  },
+  "scripts": {
+    "post-update-cmd": [
+      "@composer normalize"
+    ],
+    "test:unit": "vendor/bin/phpunit -c phpunit.xml.dist"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    cacheDirectory="var/.phpunit.cache"
+    colors="true"
+>
+    <testsuites>
+        <testsuite name="unit">
+            <directory>Tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
Treat union return types as compatible only when every possible return value matches the component definition. The updated unit coverage locks the safe subtype-only behavior in place.

related #71 
fixes #92