### PR TITLE
[BUGFIX] fix transformer lookup for normalized and inherited union types

### DIFF
--- a/Classes/Transformer/TypeTransformers.php
+++ b/Classes/Transformer/TypeTransformers.php
@@ -7,9 +7,12 @@ namespace Andersundsehr\Storybook\Transformer;
 use Andersundsehr\Storybook\Transformer\TransformerFactory;
 use RuntimeException;
 
-use function array_column;
 use function array_keys;
+use function explode;
 use function is_a;
+use function sort;
+use function str_contains;
+use function trim;
 
 use const PHP_INT_MIN;
 
@@ -52,6 +55,8 @@ final class TypeTransformers
             );
         }
 
+        $returnType = $this->normalizeType($returnType);
+
         $this->configuration[$returnType] ??= [];
         $this->configuration[$returnType][] = [
             'handler' => $handler::class,
@@ -87,6 +92,8 @@ final class TypeTransformers
 
     private function getInternal(string $returnType): ?Transformer
     {
+        $returnType = $this->normalizeType($returnType);
+
         if (isset($this->handlers[$returnType])) {
             return $this->handlers[$returnType];
         }
@@ -94,8 +101,7 @@ final class TypeTransformers
         $maxPriority = PHP_INT_MIN;
         $matched = null;
         foreach ($this->handlers as $type => $transformer) {
-            // if the requested type is contained in the transformers type, we can use it to transform
-            if (!is_a($type, $returnType, true)) {
+            if (!$this->matchesRequestedType($type, $returnType)) {
                 continue;
             }
 
@@ -115,6 +121,52 @@ final class TypeTransformers
         }
 
         return $matched;
+    }
+
+    private function matchesRequestedType(string $registeredType, string $requestedType): bool
+    {
+        foreach ($this->splitUnionType($registeredType) as $registeredTypePart) {
+            foreach ($this->splitUnionType($requestedType) as $requestedTypePart) {
+                if ($this->matchesSingleRequestedType($registeredTypePart, $requestedTypePart)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function matchesSingleRequestedType(string $registeredType, string $requestedType): bool
+    {
+        if ($this->normalizeType($registeredType) === $this->normalizeType($requestedType)) {
+            return true;
+        }
+
+        if ($registeredType === $requestedType) {
+            return true;
+        }
+
+        return is_a($registeredType, $requestedType, true);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function splitUnionType(string $type): array
+    {
+        return explode('|', $type);
+    }
+
+    private function normalizeType(string $type): string
+    {
+        if (!str_contains($type, '|')) {
+            return trim($type);
+        }
+
+        $parts = array_map(trim(...), $this->splitUnionType($type));
+        sort($parts);
+
+        return implode('|', $parts);
     }
 
     /**

--- a/Tests/Unit/Transformer/TypeTransformersTest.php
+++ b/Tests/Unit/Transformer/TypeTransformersTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Andersundsehr\Storybook\Tests\Unit\Transformer;
+
+use Generator;
+use InvalidArgumentException;
+use Throwable;
+use Andersundsehr\Storybook\Transformer\TransformerFactory;
+use Andersundsehr\Storybook\Transformer\TypeTransformers;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+use Stringable;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class TypeTransformersTest extends UnitTestCase
+{
+    /**
+     * @param list<array{type:string, priority:int}> $transformers
+     */
+    #[Test]
+    #[DataProvider('getDataProvider')]
+    public function get(array $transformers, string $type, int $expectedIndex): void
+    {
+        $subject = $this->createSubject();
+        foreach ($transformers as $index => $transformer) {
+            $returnType = $transformer['type'];
+            $priority = $transformer['priority'];
+            $classInstance = eval(sprintf("return new class() { public function __invoke(): %s {}};", $returnType));
+            $transformers[$index]['class'] = $classInstance::class;
+            $subject->addTransformer(
+                handler: $classInstance,
+                method: '__invoke',
+                returnType: $returnType,
+                priority: $priority,
+            );
+        }
+
+        self::assertEquals($transformers[$expectedIndex]['class'] . '->__invoke', $subject->get($type)->from);
+    }
+
+    public static function getDataProvider(): Generator
+    {
+        yield 'exact scalar lookup' => [
+            'transformers' => [
+                ['type' => 'string', 'priority' => 10],
+            ],
+            'type' => 'string',
+            'expectedIndex' => 0,
+        ];
+        yield 'exact union lookup prefers exact registration' => [
+            'transformers' => [
+                ['type' => 'string|int', 'priority' => 10],
+                ['type' => 'string', 'priority' => 20],
+            ],
+            'type' => 'string|int',
+            'expectedIndex' => 0,
+        ];
+        yield 'exact union lookup beats lower priority scalar' => [
+            'transformers' => [
+                ['type' => 'string|int', 'priority' => 20],
+                ['type' => 'string', 'priority' => 10],
+            ],
+            'type' => 'string|int',
+            'expectedIndex' => 0,
+        ];
+        yield 'higher priority exact union wins' => [
+            'transformers' => [
+                ['type' => 'string', 'priority' => 10],
+                ['type' => 'string|int', 'priority' => 20],
+            ],
+            'type' => 'string|int',
+            'expectedIndex' => 1,
+        ];
+        yield 'normalized union request resolves exact union registration' => [
+            'transformers' => [
+                ['type' => 'string', 'priority' => 10],
+                ['type' => 'string|int', 'priority' => 20],
+            ],
+            'type' => 'int|string',
+            'expectedIndex' => 1,
+        ];
+        yield 'narrower scalar resolves requested union' => [
+            'transformers' => [
+                ['type' => 'string', 'priority' => 10],
+            ],
+            'type' => 'string|int',
+            'expectedIndex' => 0,
+        ];
+        yield 'registered subtype resolves interface request' => [
+            'transformers' => [
+                ['type' => RuntimeException::class, 'priority' => 10],
+            ],
+            'type' => Stringable::class,
+            'expectedIndex' => 0,
+        ];
+        yield 'higher priority inherited subtype wins for parent request' => [
+            'transformers' => [
+                ['type' => RuntimeException::class, 'priority' => 10],
+                ['type' => InvalidArgumentException::class, 'priority' => 20],
+            ],
+            'type' => Throwable::class,
+            'expectedIndex' => 1,
+        ];
+        yield 'equal priority inherited subtype uses later registration' => [
+            'transformers' => [
+                ['type' => RuntimeException::class, 'priority' => 10],
+                ['type' => InvalidArgumentException::class, 'priority' => 10],
+            ],
+            'type' => Throwable::class,
+            'expectedIndex' => 1,
+        ];
+        yield 'union request resolves inherited subtype through compatible member' => [
+            'transformers' => [
+                ['type' => RuntimeException::class, 'priority' => 10],
+            ],
+            'type' => Throwable::class . '|' . Stringable::class,
+            'expectedIndex' => 0,
+        ];
+        yield 'registered union transformer resolves inherited union request' => [
+            'transformers' => [
+                ['type' => RuntimeException::class . '|' . Stringable::class, 'priority' => 10],
+            ],
+            'type' => Throwable::class . '|' . Stringable::class,
+            'expectedIndex' => 0,
+        ];
+        yield 'lower priority exact type keeps first registration' => [
+            'transformers' => [
+                ['type' => 'string', 'priority' => 20],
+                ['type' => 'string', 'priority' => 10],
+            ],
+            'type' => 'string',
+            'expectedIndex' => 0,
+        ];
+        yield 'equal priority exact type uses later registration' => [
+            'transformers' => [
+                ['type' => 'string', 'priority' => 10],
+                ['type' => 'string', 'priority' => 10],
+            ],
+            'type' => 'string',
+            'expectedIndex' => 1,
+        ];
+        yield 'higher priority exact type overrides earlier registration' => [
+            'transformers' => [
+                ['type' => 'string', 'priority' => 10],
+                ['type' => 'string', 'priority' => 20],
+            ],
+            'type' => 'string',
+            'expectedIndex' => 1,
+        ];
+    }
+
+    public function testAddTransformerThrowsIfMethodDoesNotExist(): void
+    {
+        $subject = $this->createSubject();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionCode(1988452467);
+
+        $subject->addTransformer(new class {
+        }, 'doesNotExist', 'string', 10);
+    }
+
+
+    public function testGetThrowsForUnknownOrUnmatchedType(): void
+    {
+        $subject = $this->createSubject();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionCode(1988452468);
+
+        $subject->get('string');
+    }
+
+    private function createSubject(): TypeTransformers
+    {
+        $transformerFactory = new TransformerFactory(
+            new class implements ContainerInterface {
+                public function get(string $id): mixed
+                {
+                    throw new RuntimeException('No services available in unit test container.', 1589909511);
+                }
+
+                public function has(string $id): bool
+                {
+                    return false;
+                }
+            },
+        );
+
+        return new TypeTransformers($transformerFactory);
+    }
+}


### PR DESCRIPTION
Treat union type registrations as compatible when one member matches the requested type directly or through inheritance. This makes the TypeTransformers unit coverage green for reordered and inherited unions.

closes #71 