### PR TITLE
Fix EXT: asset resolution in PreviewAssetRenderer

### DIFF
--- a/Classes/Service/PreviewAssetRenderer.php
+++ b/Classes/Service/PreviewAssetRenderer.php
@@ -8,6 +8,7 @@ use Andersundsehr\Storybook\Dto\RenderJob;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Page\AssetCollector;
 use TYPO3\CMS\Core\Page\AssetRenderer;
+use TYPO3\CMS\Core\Utility\PathUtility;
 
 use function array_filter;
 use function implode;
@@ -60,6 +61,10 @@ final readonly class PreviewAssetRenderer
 
     private function changeUrl(string $source, string $iframeContextId): string
     {
+        if (str_starts_with($source, 'EXT:')) {
+            $source = PathUtility::getPublicResourceWebPath($source);
+        }
+
         if (str_contains($source, '/@vite')) {
             // if you include /@vite/client or /@vite-plugin-checker-runtime-entry
             // we do not want to reload it every time as that is not necessary


### PR DESCRIPTION
Uses PathUtility to convert TYPO3 'EXT:' paths to public web paths so assets from extensions are loaded correctly.


Case A (now supported):
`<f:asset.css identifier="example" href="EXT:my_ext/Resources/Public/Css/style.css" />`

Case B (still working):
```
<f:asset.css identifier="example:button">
    .btn { color: red; }
</f:asset.css>
```
